### PR TITLE
Add FastAPI web prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Calorie Watch Prototype
+
+This prototype allows uploading a picture of food and returns estimated calorie information using Google's Generative AI models.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export your API key:
+   ```bash
+   export GEMINI_API_KEY=your-key-here
+   ```
+3. Start the server:
+   ```bash
+   python app.py
+   ```
+4. Open `http://localhost:8000` in your browser and upload a food image.
+
+The server uses FastAPI and the `google-generativeai` client. Deploying on Vercel requires a Python runtime.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,64 @@
+import os
+from fastapi import FastAPI, File, UploadFile, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+try:
+    from google import genai
+    from google.genai import types
+except ImportError:  # pragma: no cover - library might not be available during tests
+    genai = None
+    types = None
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+
+def analyze_image(image_bytes: bytes) -> str:
+    """Call Google Generative AI to analyze the image."""
+    if genai is None:
+        raise RuntimeError("google-generativeai library not installed")
+
+    client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+    model = "gemini-pro-vision"
+
+    contents = [
+        types.Content(
+            role="user",
+            parts=[
+                types.Part.from_data(mime_type="image/jpeg", data=image_bytes),
+                types.Part.from_text(
+                    "Provide the name of the food in this image and an approximate calorie count."
+                ),
+            ],
+        )
+    ]
+
+    config = types.GenerateContentConfig(response_mime_type="text/plain")
+    response = client.models.generate_content(
+        model=model,
+        contents=contents,
+        config=config,
+    )
+    return response.text
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/analyze")
+async def analyze(file: UploadFile = File(...)):
+    image_bytes = await file.read()
+    try:
+        result = analyze_image(image_bytes)
+    except Exception as exc:  # pragma: no cover - runtime error handling
+        result = str(exc)
+    return {"result": result}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+jinja2
+python-multipart
+google-generativeai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Calorie Watch</title>
+</head>
+<body>
+    <h1>Calorie Watch</h1>
+    <form id="upload-form" enctype="multipart/form-data">
+        <input type="file" name="file" accept="image/*" />
+        <button type="submit">Analyze</button>
+    </form>
+    <pre id="result"></pre>
+    <script>
+        const form = document.getElementById('upload-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const fileInput = form.querySelector('input[name="file"]');
+            if (!fileInput.files.length) return;
+            const formData = new FormData();
+            formData.append('file', fileInput.files[0]);
+            const res = await fetch('/analyze', { method: 'POST', body: formData });
+            const data = await res.json();
+            document.getElementById('result').textContent = data.result;
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a basic FastAPI server using the Google Generative AI client
- provide an HTML upload form
- add requirements and usage instructions

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_683f849a0398833081a510740b1fcb11